### PR TITLE
Fix #1: Page refresh for routes other than home results in HTTP 404

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ FROM nginx:stable-alpine
 # Copy the build output to Nginx's HTML directory
 COPY --from=build /app/dist /usr/share/nginx/html
 
+# Copy custom Nginx configuration file
+COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
 # Expose port 80
 EXPOSE 80
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        # This line tries to serve the requested file first,
+        # if not found, it falls back to index.html
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /static/ {
+        # Handle static assets
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
During local development with `npm run dev`, the development server (Vite) is typically configured to always serve index.html for any route, allowing React Router to handle the routing. 

When the app deployed via Docker Compose, the web server (Nginx) is serving the static files. However, it’s not configured to serve index.html for routes other than /. So, upon refresh on `/courses` or `/course-instances`, the server looks for a file or directory at  `/courses` or `/course-instances`, doesn't find it, and returns a 404.

This PR includes configuring the web server to redirect all requests to index.html, allowing React Router to take over and handle the routing on the client side.

Fixes #1 